### PR TITLE
Issue#65: Propagate CODYCO_USES_MATLAB to qpOASES.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ set(YCM_USE_CMAKE_PROPOSED TRUE CACHE BOOL "Use files including unmerged cmake p
 
 #options to build specific software or use a reduced set of dependencies
 option(CODYCO_USES_MATLAB "Enable compilation of software that depend on Matlab" FALSE)
+option(CODYCO_MATLAB_DEPENDENCIES_CUSTOM "Enables the custom selection of some Matlab dependencies" FALSE)
 option(CODYCO_USES_LUA "Enable compilation of software that depend on Lua" FALSE)
 option(CODYCO_USES_PYTHON "Enable compilation of software that depend on Python" FALSE)
 option(CODYCO_USES_WBI_TOOLBOX "Whole Body Interface Toolbox - Simulink library" FALSE)
@@ -94,6 +95,12 @@ endif()
 
 #additional modules
 find_or_build_package(comStepper)
+
+#Set WBI-Toolbox and mexWholeBodyModel variables depending on CODYCO_USES_MATLAB
+if(NOT ${CODYCO_MATLAB_DEPENDENCIES_CUSTOM})
+    set(CODYCO_USES_WBI_TOOLBOX ${CODYCO_USES_MATLAB} CACHE BOOL "Whole Body Interface Toolbox - Simulink library" FORCE)
+    set(CODYCO_USES_MEX_WHOLEBODYMODEL ${CODYCO_USES_MATLAB} CACHE BOOL "Enable to compile the matlab mex inteface for iWholeBodyModel" FORCE)
+endif()
 
 #WBI-Toolbox
 if( ${CODYCO_USES_WBI_TOOLBOX} )

--- a/cmake/BuildiDynTree.cmake
+++ b/cmake/BuildiDynTree.cmake
@@ -21,7 +21,7 @@ ycm_ep_helper(iDynTree TYPE GIT
               TAG master
               COMPONENT libraries
               CMAKE_CACHE_ARGS -DIDYNTREE_ENABLE_URDF:BOOL=ON
-              CMAKE_ARGS -DIDYNTREE_USES_MATLAB:BOOL=${CODYCO_USES_MATLAB}
+#             CMAKE_ARGS -DIDYNTREE_USES_MATLAB:BOOL=${CODYCO_USES_MATLAB}
               DEPENDS YARP
                       ICUB
                       orocos_kdl

--- a/cmake/BuildqpOASES.cmake
+++ b/cmake/BuildqpOASES.cmake
@@ -25,4 +25,5 @@ ycm_ep_helper(qpOASES TYPE GIT
               STYLE GITHUB
               REPOSITORY robotology-playground/qpOASES.git
               TAG master
-              COMPONENT external)
+              COMPONENT external
+              CMAKE_ARGS -DQPOASES_BUILD_BINDINGS_MATLAB:BOOL=${CODYCO_USES_MATLAB})


### PR DESCRIPTION
This fixes issue https://github.com/robotology/codyco-superbuild/issues/65.

Propagated `CODYCO_USES_MATLAB` to qpOASES project (`CODYCO_USES_MATLAB` sets `QPOASES_BUILD_BINDINGS_MATLAB`).

Deactivated propagation of `CODYCO_USES_MATLAB` to iDynTree project, because iDynTree is not compiling with `IDYNTREE_USES_MATLAB` due to SWIG vs MATLAB versions compatibility.

Set Matlab dependencies automatically from `CODYCO_USES_MATLAB` at superbuild CMakeLists level : 
+ `CODYCO_USES_MATLAB` sets `CODYCO_USES_WBI_TOOLBOX` and `CODYCO_USES_MEX_WHOLEBODYMODEL` in the cache (forced values) if we desire automatic configuration (`CODYCO_MATLAB_DEPENDENCIES_CUSTOM` set to `OFF`)
+ if `CODYCO_MATLAB_DEPENDENCIES_CUSTOM` set to `ON`, we can set these MATLAB dependencies manually
+ `CODYCO_MATLAB_DEPENDENCIES_CUSTOM` default value is `OFF`