### PR TITLE
added a startup.m for toolbox that use matlab

### DIFF
--- a/.startup_codyco_superbuild.m.in
+++ b/.startup_codyco_superbuild.m.in
@@ -16,11 +16,11 @@ if exist(mexDir, 'dir')
 end
 
 if exist(mexUtDir, 'dir')
-    addpath(mexDir);
+    addpath(mexUtDir);
 end
 
 if exist(mexWrapDir, 'dir')
-    addpath(mexDir);
+    addpath(mexWrapDir);
 end
 
 if exist(shareDir, 'dir')

--- a/.startup_codyco_superbuild.m.in
+++ b/.startup_codyco_superbuild.m.in
@@ -1,0 +1,55 @@
+%% startup_codyco_superbuild.m
+%  Run this script only once to permanently add the required folders for using MATLAB toolbox (e.g. WBToolbox, mexWholeBodyModel) to your 
+%  MATLAB path. 
+
+fprintf('\nMATLAB Toolbox\n');
+
+installDir = '@CMAKE_BINARY_DIR@/install';
+mexDir     = [installDir, filesep, 'mex'];
+mexWrapDir = [mexDir, filesep, 'mexwbi-wrappers'];
+mexUtDir   = [mexDir, filesep, 'mexwbi-utilities'];
+shareDir   = [installDir, filesep, 'share/WB-Toolbox'];
+imgDir     = [shareDir, filesep, 'images'];
+
+if exist(mexDir, 'dir')
+    addpath(mexDir);
+end
+
+if exist(mexUtDir, 'dir')
+    addpath(mexDir);
+end
+
+if exist(mexWrapDir, 'dir')
+    addpath(mexDir);
+end
+
+if exist(shareDir, 'dir')
+    addpath(shareDir);
+end
+
+if exist(imgDir, 'dir')
+    addpath(imgDir);
+end
+
+fileDir               = userpath;
+pathSeparatorLocation = strfind(fileDir, pathsep);
+
+if isempty(fileDir)
+    error('Empty userpath. Please set the userpath before running this script');
+elseif size(pathSeparatorLocation, 2) > 1
+    error('Multiple userpaths. Please set a single userpath before running this script');
+end
+
+if (~isempty(pathSeparatorLocation))
+    fileDir(pathSeparatorLocation) = [];
+end
+
+fprintf('Saving paths to %s\n\n', [fileDir, filesep, 'pathdef.m']);
+
+if (~savepath([fileDir, filesep, 'pathdef.m']))
+    fprintf(['A file called pathdef.m has been created in your %s folder.\n', ...
+        'This should be enough to permanentely add all the MATLAB-Toolbox to ', ...
+        'your MATLAB installation.\n'], fileDir);
+else
+    disp('There was an error generating pathdef.m To proceed please manually add the contents of variables mexDir, mexUtDir, mexWrapDir, shareDir and imgDir to your matlabpath');
+end

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,14 @@ find_or_build_package(yarpWholeBodyInterface)
 
 find_or_build_package(codyco-modules)
 
+#STARTUP MATLAB TOOLBOX
+if (${CODYCO_USES_MATLAB})
+# The following line is to properly configure the installation script of the MATLAB toolbox
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/.startup_codyco_superbuild.m.in ${CMAKE_BINARY_DIR}/startup_codyco_superbuild.m)
+# Install configuration files
+install(FILES ${CMAKE_BINARY_DIR}/startup_codyco_superbuild.m DESTINATION ${CMAKE_BINARY_DIR})
+endif()
+
 #codyco isir modules
 if(${CODYCO_USES_KDL} AND ${CODYCO_BUILD_OCRA_MODULES} )
     find_or_build_package(ocra-wbi-plugins)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,10 +101,10 @@ find_or_build_package(codyco-modules)
 
 #STARTUP MATLAB TOOLBOX
 if (${CODYCO_USES_MATLAB})
-# The following line is to properly configure the installation script of the MATLAB toolbox
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/.startup_codyco_superbuild.m.in ${CMAKE_BINARY_DIR}/startup_codyco_superbuild.m)
-# Install configuration files
-install(FILES ${CMAKE_BINARY_DIR}/startup_codyco_superbuild.m DESTINATION ${CMAKE_BINARY_DIR})
+    # The following line is to properly configure the installation script of the MATLAB toolbox
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/.startup_codyco_superbuild.m.in ${CMAKE_BINARY_DIR}/startup_codyco_superbuild.m)
+    # Install configuration files
+    install(FILES ${CMAKE_BINARY_DIR}/startup_codyco_superbuild.m DESTINATION ${CMAKE_BINARY_DIR})
 endif()
 
 #codyco isir modules

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Table of Contents
   * [Superbuild structure](#superbuild-structure)
   * [Installation](#installation)
     * [Linux](#linux)
-    * [macOS](#macOS)
+    * [macOS](#macos)
     * [Windows](#windows)
   * [Update](#update)
   * [MATLAB software](#matlab-software)
@@ -315,6 +315,7 @@ can install some libraries that depend on MATLAB, in particular:
  * MATLAB bindings of the [iDynTree](https://github.com/robotology/idyntree) library.
  * MATLAB bindings of the [qpOASES](https://github.com/robotology-dependencies/qpOASES) library.
  * The [WB-Toolbox](https://github.com/robotology/WB-Toolbox) Simulink toolbox. 
+ * The [mexWholeBodyModel](https://github.com/robotology/mex-wholebodymodel) toolbox.
  
 To use this software, you can simply enable its compilation using the `CODYCO_USES_MATLAB` CMake option. 
 Once this software has been compiled by the superbuild, you just need to add some directories of the codyco-superbuild install (typically `$CODYCO_SUPERBUILD_ROOT/build/install`) to [the MATLAB path](http://mathworks.com/help/matlab/matlab_env/add-folders-to-search-path-upon-startup-on-unix-or-macintosh.html).
@@ -326,7 +327,8 @@ As an example, you could add this line to your MATLAB script that uses the codyc
     addpath(genpath(['codyco_superbuild_install_folder'  /share/WB-Toolbox]))
 ~~~
 Anyway we strongly suggest that you add this directories to the MATLAB path in robust way, 
-for example by modifyng the `startup.m` or the `MATLABPATH` enviromental variable [as described in official MATLAB documentation](http://mathworks.com/help/matlab/matlab_env/add-folders-to-search-path-upon-startup-on-unix-or-macintosh.html)
+for example by modifyng the `startup.m` or the `MATLABPATH` enviromental variable [as described in official MATLAB documentation](http://mathworks.com/help/matlab/matlab_env/add-folders-to-search-path-upon-startup-on-unix-or-macintosh.html).
+Another way is to run (only once) the script `startup_codyco_superbuild.m` in the `$CODYCO_SUPERBUILD_ROOT/build` folder. This should be enough to permanently add the required paths for all the toolbox that use MATLAB. 
 
 For more info on configuring MATLAB software with the codyco-superbuild, please check the [WB-Toolbox README](https://github.com/robotology/WB-Toolbox).
 
@@ -338,5 +340,7 @@ For more info on configuring MATLAB software with the codyco-superbuild, please 
 
 Controllers
 -----------
-MATLAB controllers developed in the CoDyCo project are available in the [WBI-Toolbox-controllers](https://github.com/robotology-playground/WBI-Toolbox-controllers) repository. 
-Given that some users want to fully control this repository, it is not downloaded automically if you select the `CODYCO_USES_MATLAB` option. To download this repository as part of the superbuild, just enable the `CODYCO_USES_WBI_TOOLBOX_CONTROLLERS` CMake option. 
+MATLAB balancing controllers developed for the CoDyCo project are available in the [WBI-Toolbox-controllers](https://github.com/robotology-playground/WBI-Toolbox-controllers) and 
+[mexWholeBodyModel](https://github.com/robotology/mex-wholebodymodel) repositories. 
+The `mexWholeBodyModel` toolbox is downloaded automatically if the option `CODYCO_USES_MATLAB` is enabled, while
+to download `WBI-Toolbox-controllers` as part of the superbuild, the user must enable the `CODYCO_USES_WBI_TOOLBOX_CONTROLLERS` CMake option. 


### PR DESCRIPTION
The toolbox that use MATLAB sometimes require to add some folders to MATLAB path. The script `startup_codyco_superbuild.m` allows to permanently add the required folders to the MATLAB path for both the WBToolbox and the mexWholeBodyModel toolbox. 