### PR TITLE
Added support to compile the yarp matlab bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,9 @@ set(YCM_USE_CMAKE_PROPOSED TRUE CACHE BOOL "Use files including unmerged cmake p
 option(CODYCO_USES_MATLAB "Enable compilation of software that depend on Matlab and Simulink" FALSE)
 option(CODYCO_NOT_USE_SIMULINK "Disable compilation of software that depend on Simulink" FALSE)
 mark_as_advanced(CODYCO_NOT_USE_SIMULINK)
+#temporary option, useful to disable compilation of yarp-matlab-bindings 
+option(CODYCO_NOT_USE_YARP_MATLAB_BINDINGS "Disable compilation of yarp-matlab-bindings" FALSE)
+mark_as_advanced(CODYCO_NOT_USE_YARP_MATLAB_BINDINGS)
 option(CODYCO_USES_WBI_TOOLBOX "Legacy version of Whole Body Interface Toolbox 1.0 - Simulink library" FALSE)
 option(CODYCO_USES_WBI_TOOLBOX_CONTROLLERS "Controllers and Simulink models created/used with the WBI-Toolbox" FALSE)
 
@@ -102,6 +105,11 @@ find_or_build_package(codyco-modules)
 #codyco isir modules
 if(${CODYCO_USES_KDL} AND ${CODYCO_BUILD_OCRA_MODULES} )
     find_or_build_package(ocra-wbi-plugins)
+endif()
+
+#yarp-matlab-bindings
+if(${CODYCO_USES_MATLAB} AND NOT ${CODYCO_NOT_USE_YARP_MATLAB_BINDINGS})
+    find_or_build_package(yarp-matlab-bindings)
 endif()
 
 #WB-Toolbox

--- a/cmake/Buildyarp-matlab-bindings.cmake
+++ b/cmake/Buildyarp-matlab-bindings.cmake
@@ -1,0 +1,13 @@
+# yarp-matlab-bindings
+include(YCMEPHelper)
+include(FindOrBuildPackage)
+
+find_or_build_package(YARP QUIET)
+
+
+ycm_ep_helper(yarp-matlab-bindings TYPE GIT
+              STYLE GITHUB
+              REPOSITORY robotology-playground/yarp-matlab-bindings.git
+              TAG master
+              COMPONENT libraries
+              DEPENDS YARP)


### PR DESCRIPTION
This commit adds support for compiling the native [`yarp-matlab-bindings`](https://github.com/robotology-playground/yarp-matlab-bindings). 

The bindings in the repo are generated using the same swig-matlab commit of iDynTree (as some used file are shared, and it is better that they are not out of sync). The bindings are generated against the `master` branch of YARP, but they have been tested to be also compatibly with the `devel` branch (mainly because master is API level compatible with devel). 

Compilation is enabled when `CODYCO_USES_MATLAB` option is enabled, but as an emergency measure  I also added a `CODYCO_NOT_USE_YARP_MATLAB_BINDINGS` option to disable just compilation of `yarp-matlab-bindings` if there are any problems. 

This will slightly increase compilation time, but I think it is worth it. This bindings permits for example to access the YARP's ResourceFinder, for example: 

```
>> yarp.Network.getEnvironment('YARP_ROBOT_NAME')

ans =

icubGazeboSim

>> confFile = yarp.ResourceFinder.getResourceFinderSingleton.findFileByName('yarpWholeBodyInterface.ini')

confFile =

/home/pegua/src/codyco-superbuild/build/install/share/codyco/robots/icubGazeboSim/yarpWholeBodyInterface.ini

>> prop = yarp.Property;
>> prop.fromConfigFile(confFile);
>> prop.toString

ans =

(urdf model.urdf) (WBI_YARP_FT_PORTS (l_arm_ft_sensor "/left_arm/analog:o") (r_arm_ft_sensor "/right_arm/analog:o") (l_leg_ft_sensor "/left_leg/analog:o") (l_foot_ft_sensor "/left_foot/analog:o") (r_leg_ft_sensor "/right_leg/analog:o") (r_foot_ft_sensor "/right_foot/analog:o")) (getLimitsFromControlBoard) (WBI_YARP_JOINTS (torso_yaw (torso 0)) (torso_roll (torso 1)) (torso_pitch (torso 2)) (neck_pitch (head 0)) (neck_roll (head 1)) (neck_yaw (head 2)) (l_shoulder_pitch (left_arm 0)) (l_shoulder_roll (left_arm 1)) (l_shoulder_yaw (left_arm 2)) (l_elbow (left_arm 3)) (l_wrist_prosup (left_arm 4)) (l_wrist_pitch (left_arm 5)) (l_wrist_yaw (left_arm 6)) (r_shoulder_pitch (right_arm 0)) (r_shoulder_roll (right_arm 1)) (r_shoulder_yaw (right_arm 2)) (r_elbow (right_arm 3)) (r_wrist_prosup (right_arm 4)) (r_wrist_pitch (right_arm 5)) (r_wrist_yaw (right_arm 6)) (l_hip_pitch (left_leg 0)) (l_hip_roll (left_leg 1)) (l_hip_yaw (left_leg 2)) (l_knee (left_leg 3)) (l_ankle_pitch (left_leg 4)) (l_ankle_roll (left_leg 5)) (r_hip_pitch (right_leg 0)) (r_hip_roll (right_leg 1)) (r_hip_yaw (right_leg 2)) (r_knee (right_leg 3)) (r_ankle_pitch (right_leg 4)) (r_ankle_roll (right_leg 5))) (robot icubGazeboSim) (WBI_STATE_OPTIONS (estimateBaseState) (localWorldReferenceFrame codyco_balancing_world)) (WBI_ID_LISTS (ROBOT_HEAD_JOINTS (neck_pitch neck_roll neck_yaw)) (ROBOT_TORSO_JOINTS (torso_pitch torso_roll torso_yaw)) (ROBOT_LEFT_ARM_JOINTS (l_shoulder_pitch l_shoulder_roll l_shoulder_yaw l_elbow l_wrist_prosup)) (ROBOT_RIGHT_ARM_JOINTS (r_shoulder_pitch r_shoulder_roll r_shoulder_yaw r_elbow r_wrist_prosup)) (ROBOT_LEFT_ARM_DYNAMIC_MODEL_JOINTS (ROBOT_LEFT_ARM_JOINTS l_wrist_pitch l_wrist_yaw)) (ROBOT_RIGHT_ARM_DYNAMIC_MODEL_JOINTS (ROBOT_RIGHT_ARM_JOINTS r_wrist_pitch r_wrist_yaw)) (ROBOT_LEFT_LEG_JOINTS (l_hip_pitch l_hip_roll l_hip_yaw l_knee l_ankle_pitch l_ankle_roll)) (ROBOT_RIGHT_LEG_JOINTS (r_hip_pitch r_hip_roll r_hip_yaw r_knee r_ankle_pitch r_ankle_roll)) (ROBOT_DYNAMIC_MODEL_JOINTS (ROBOT_TORSO_JOINTS ROBOT_HEAD_JOINTS ROBOT_LEFT_ARM_DYNAMIC_MODEL_JOINTS ROBOT_RIGHT_ARM_DYNAMIC_MODEL_JOINTS ROBOT_LEFT_LEG_JOINTS ROBOT_RIGHT_LEG_JOINTS)) (ROBOT_MAIN_JOINTS (ROBOT_TORSO_JOINTS ROBOT_LEFT_ARM_JOINTS ROBOT_RIGHT_ARM_JOINTS ROBOT_LEFT_LEG_JOINTS ROBOT_RIGHT_LEG_JOINTS)) (ROBOT_TORQUE_CONTROL_JOINTS (ROBOT_TORSO_JOINTS ROBOT_LEFT_ARM_JOINTS ROBOT_RIGHT_ARM_JOINTS ROBOT_LEFT_LEG_JOINTS ROBOT_RIGHT_LEG_JOINTS)) (ROBOT_TORQUE_CONTROL_JOINTS_WITHOUT_PRONOSUP (ROBOT_TORSO_JOINTS l_shoulder_pitch l_shoulder_roll l_shoulder_yaw l_elbow r_shoulder_pitch r_shoulder_roll r_shoulder_yaw r_elbow ROBOT_LEFT_LEG_JOINTS ROBOT_RIGHT_LEG_JOINTS)) (ROBOT_MEX_WBI_TOOLBOX (ROBOT_TORSO_JOINTS ROBOT_LEFT_ARM_JOINTS ROBOT_RIGHT_ARM_JOINTS ROBOT_LEFT_LEG_JOINTS ROBOT_RIGHT_LEG_JOINTS)) (ROBOT_JOINTS_WALKING_IK (ROBOT_LEFT_LEG_JOINTS ROBOT_RIGHT_LEG_JOINTS ROBOT_TORSO_JOINTS)) (ROBOT_MAIN_IMUS (imu_frame)) (ROBOT_LEFT_ARM_FTS (l_arm_ft_sensor)) (ROBOT_RIGHT_ARM_FTS (r_arm_ft_sensor)) (ROBOT_LEFT_LEG_FTS (l_leg_ft_sensor l_foot_ft_sensor)) (ROBOT_RIGHT_LEG_FTS (r_leg_ft_sensor r_foot_ft_sensor)) (ROBOT_MAIN_FTS (ROBOT_LEFT_ARM_FTS ROBOT_RIGHT_ARM_FTS ROBOT_LEFT_LEG_FTS ROBOT_RIGHT_LEG_FTS))) (WBI_YARP_IMU_PORTS (imu_frame "/inertial")) (verbose)
>> 
```

This should simplify accessing YARP configuration files from MATLAB. 
Furthermore is necessary to provide a complete iDynTree-based shim to mex-wholeBodyModel, see https://github.com/robotology/mex-wholebodymodel/issues/75 .

cc @francesco-romano @DanielePucci @S-Dafarra .
