### PR TITLE
Use Git mirror for Eigen3 and fix AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,6 +64,7 @@ build_script:
   - md build
   - cd build
   - cmake -G"Visual Studio 12" -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DYCM_BOOTSTRAP_VERBOSE:BOOL=TRUE ..
+  - cmake --build . --target UPDATE_ALL
   - msbuild /m /p:Configuration=Release /p:Platform="Win32" codyco-superbuild.sln
 
 notifications:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,7 +64,7 @@ build_script:
   - md build
   - cd build
   - cmake -G"Visual Studio 12" -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DYCM_BOOTSTRAP_VERBOSE:BOOL=TRUE ..
-  - cmake --build . --target UPDATE_ALL
+  - cmake --build . --target ALL_UPDATE
   - msbuild /m /p:Configuration=Release /p:Platform="Win32" codyco-superbuild.sln
 
 notifications:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,6 +60,8 @@ build:
 
 build_script:
   - cd c:\dev\codyco-superbuild
+  # workaround for https://github.com/robotology/codyco-superbuild/issues/148
+  - rd /q /s "c:\dev\codyco-superbuild\external" 2>nul
   - md build
   - cd build
   - cmake -G"Visual Studio 12" -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DYCM_BOOTSTRAP_VERBOSE:BOOL=TRUE ..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,8 +60,7 @@ build:
 
 build_script:
   - cd c:\dev\codyco-superbuild
-  # workaround for https://github.com/robotology/codyco-superbuild/issues/148
-  - rd /q /s "c:\dev\codyco-superbuild\external" 2>nul
+  - dir "c:\dev\codyco-superbuild"
   - md build
   - cd build
   - cmake -G"Visual Studio 12" -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DYCM_BOOTSTRAP_VERBOSE:BOOL=TRUE ..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,6 +49,7 @@ build:
 
 build_script:
   - cd c:\dev\codyco-superbuild
+  - rmdir build /s
   - md build
   - cd build
   - cmake -G"Visual Studio 12" -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DYCM_BOOTSTRAP_VERBOSE:BOOL=TRUE ..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,7 @@ environment:
   ICUB_DIR:          c:/Program Files (x86)/robotology/icub-1.4.0
   BOOST_ROOT:        C:\Libraries\boost
   BOOST_LIBRARYDIR:  C:\Libraries\boost\lib32-msvc-12.0
+  EIGEN3_ROOT        c:\dev\Eigen3\include\eigen3
   
 
 install:
@@ -44,12 +45,21 @@ install:
   - cmd: timeout 10
   - cmd: dir "c:\Program Files (x86)\robotology"
 
+  - cmd: if not exist c:\dev\Eigen3\include\eigen3\Eigen\Core (
+            curl -L -o eigen-eigen-dc6cfdf9bcec.tar.gz https://bitbucket.org/eigen/eigen/get/3.2.9.tar.gz &&
+            cmake -E tar zxf eigen-eigen-dc6cfdf9bcec.tar.gz &&
+            cd eigen-eigen-dc6cfdf9bcec &&
+            mkdir build &&
+            cd build &&
+            cmake -G "Visual Studio 12" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX="c:\dev\Eigen3" .. &&
+            cmake --build . --target install --config Debug &&
+            cd ..\..
+         ) else (echo Using cached Eigen3)
 
 build:
 
 build_script:
   - cd c:\dev\codyco-superbuild
-  - rmdir build /s /q 
   - md build
   - cd build
   - cmake -G"Visual Studio 12" -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DYCM_BOOTSTRAP_VERBOSE:BOOL=TRUE ..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,7 +49,7 @@ build:
 
 build_script:
   - cd c:\dev\codyco-superbuild
-  - rmdir build /s
+  - rmdir build /s /q 
   - md build
   - cd build
   - cmake -G"Visual Studio 12" -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DYCM_BOOTSTRAP_VERBOSE:BOOL=TRUE ..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ environment:
   ICUB_DIR:          c:/Program Files (x86)/robotology/icub-1.4.0
   BOOST_ROOT:        C:\Libraries\boost
   BOOST_LIBRARYDIR:  C:\Libraries\boost\lib32-msvc-12.0
-  EIGEN3_ROOT        c:\dev\Eigen3\include\eigen3
+  EIGEN3_ROOT:       C:\dev\Eigen3\include\eigen3
   
 
 install:

--- a/cmake/BuildEigen3.cmake
+++ b/cmake/BuildEigen3.cmake
@@ -20,7 +20,7 @@
 
 include(YCMEPHelper)
 
-ycm_ep_helper(Eigen3 TYPE HG
-                     STYLE BITBUCKET
-                     REPOSITORY eigen/eigen
-                     TAG 3.3-beta1)
+ycm_ep_helper(Eigen3 TYPE GIT
+                     STYLE GITHUB
+                     REPOSITORY RLovelett/eigen
+                     TAG 3.3-beta2)


### PR DESCRIPTION
Simplifies installation on Windows, removing the need to install mercurial. 
As in https://github.com/robotology/idyntree-superbuild/commit/abddac63c4e4fc01cf8cacfd98d3bc07d2951a24

(Hopefully could also fix https://github.com/robotology/codyco-superbuild/issues/148).