### PR TITLE
Add support for downloading and installing gazebo plugins and models

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,7 +161,8 @@ endif()
 # Gazebo related projects
 if(${CODYCO_USES_GAZEBO})
     find_or_build_package(GazeboYARPPlugins)
-    #find_or_build_package(icub-gazebo)
+    find_or_build_package(icub-gazebo)
+    find_or_build_package(icub-gazebo-wholebody)
 endif()
 
 #Documentation

--- a/cmake/Buildicub-gazebo-wholebody.cmake
+++ b/cmake/Buildicub-gazebo-wholebody.cmake
@@ -1,8 +1,8 @@
 include(YCMEPHelper)
 
-ycm_ep_helper(icub-gazebo
+ycm_ep_helper(icub-gazebo-wholebody
               TYPE GIT
               STYLE GITHUB
-              REPOSITORY robotology/icub-gazebo.git
+              REPOSITORY robotology-playground/icub-gazebo-wholebody.git
               TAG master
               COMPONENT main)


### PR DESCRIPTION
This PR fixes the `CODYCO_USES_GAZEBO` option, that until now has been set to OFF automatically. 
Now the option is still set automatically to OFF, but it is working and is compiling the `gazebo-yarp-plugins` and installing the models in `icub-gazebo` and `icub-gazebo-wholebody` . 
To use the plugins and models managed by the superbuild, add `<CODYCO_SUPERBUILD_BUILD>/install/lib` to `GAZEBO_PLUGIN_PATH` or `LD_LIBRARY_PATH/DYLD_LIBRARY_PATH` and `<CODYCO_SUPERBUILD_BUILD>/install/share/gazebo/models` to `GAZEBO_MODEL_PATH`. 

cc @gabrielenava @S-Dafarra  If you have access to the laptop, can you test it? Thanks. 