### PR TITLE
Update urdfdom/urdfdom_headers to upstream 0.4 version

### DIFF
--- a/cmake/Buildconsole_bridge.cmake
+++ b/cmake/Buildconsole_bridge.cmake
@@ -2,12 +2,8 @@
 include(YCMEPHelper)
 include(FindOrBuildPackage)
 
-find_or_build_package(Boost QUIET)
-
 ycm_ep_helper(console_bridge TYPE GIT
               STYLE GITHUB
               REPOSITORY ros/console_bridge.git
-              TAG master
-              COMPONENT external
-              CMAKE_CACHE_ARGS -DBUILD_SHARED_LIBS:BOOL=ON
-			  DEPENDS Boost)
+              TAG 0.3.2
+              COMPONENT external)

--- a/cmake/Buildurdfdom.cmake
+++ b/cmake/Buildurdfdom.cmake
@@ -3,14 +3,14 @@ include(YCMEPHelper)
 include(FindOrBuildPackage)
 
 find_or_build_package(TinyXML QUIET)
+find_or_build_package(console_bridge  QUIET)
 find_or_build_package(urdfdom_headers QUIET)
 
 ycm_ep_helper(urdfdom TYPE GIT
               STYLE GITHUB
-              REPOSITORY robotology-dependencies/urdfdom.git
-              TAG master
+              REPOSITORY ros/urdfdom.git
+              TAG 0.4.2
               COMPONENT external
-              DEPENDS urdfdom_headers
-                      TinyXML
-              CMAKE_CACHE_ARGS -DURDFDOM_DO_NOT_INSTALL_URDFPARSERPY:BOOL=ON
-                               -DURDFDOM_DO_NOT_USE_CONSOLEBRIDGE:BOOL=ON)
+              DEPENDS console_bridge
+                      urdfdom_headers
+                      TinyXML)

--- a/cmake/Buildurdfdom.cmake
+++ b/cmake/Buildurdfdom.cmake
@@ -9,7 +9,7 @@ find_or_build_package(urdfdom_headers QUIET)
 ycm_ep_helper(urdfdom TYPE GIT
               STYLE GITHUB
               REPOSITORY ros/urdfdom.git
-              TAG 0.4.2
+              TAG 0.4
               COMPONENT external
               DEPENDS console_bridge
                       urdfdom_headers

--- a/cmake/Buildurdfdom_headers.cmake
+++ b/cmake/Buildurdfdom_headers.cmake
@@ -7,7 +7,7 @@ find_or_build_package(TinyXML QUIET)
 
 ycm_ep_helper(urdfdom_headers TYPE GIT
               STYLE GITHUB
-              REPOSITORY traversaro/urdfdom_headers.git
-              TAG master
+              REPOSITORY ros/urdfdom_headers.git
+              TAG 0.4.2
               COMPONENT external
               DEPENDS TinyXML)


### PR DESCRIPTION
We switched to our forks mainly for Windows support
and to work around https://github.com/ros/urdfdom_headers/issues/18 ,
but since then the fix of the rpy handling issue has been released
in version 0.4 .

Furthermore, iDynTree on Windows used by default its own vendored urdfdom,
that however is only used for the legacy KDL classes.

For this reason we update to urdfdom to the latest 0.4 version (to avoid
incompatibilites if a user in Xenial installs both the packaged version of urdfdom
and do not clean up his install folder). On macOS tipically the user
install Gazebo before installing the superbuild, and so they get
urdfdom 1.0.0 installed by OSRF homebrew.
Eventually we should remove altogether urdfdom from the superbuild and
always rely on the one provided by the system package manager, but
I am a bit afraid that there are around release of urdfdom < 0.4 that
are affected by  https://github.com/ros/urdfdom_headers/issues/18 .
Enforcing the urdfdom version to be >= 0.4 is probably the right way to go
in the long run.