### PR TITLE
Fix codyco-superbuild

### DIFF
--- a/cmake/ProjectsTags.cmake
+++ b/cmake/ProjectsTags.cmake
@@ -1,1 +1,1 @@
-
+set(ICUB_TAG devel)


### PR DESCRIPTION
`yarp` has been released, while `icub-main` still needs to be released. Setting the `ICUB_TAG` to devel as a temporary workaround.