### PR TITLE
Add icub-models repository to the superbuild

### DIFF
--- a/cmake/Buildicub-models.cmake
+++ b/cmake/Buildicub-models.cmake
@@ -1,0 +1,8 @@
+include(YCMEPHelper)
+
+ycm_ep_helper(icub-models
+              TYPE GIT
+              STYLE GITHUB
+              REPOSITORY robotology-playground/icub-models.git
+              TAG master
+              COMPONENT main)

--- a/cmake/BuildyarpWholeBodyInterface.cmake
+++ b/cmake/BuildyarpWholeBodyInterface.cmake
@@ -5,6 +5,7 @@ find_or_build_package(YARP QUIET)
 find_or_build_package(ICUB QUIET)
 find_or_build_package(iDynTree QUIET)
 find_or_build_package(wholeBodyInterface QUIET)
+find_or_build_package(icub-models QUIET)
 
 
 ycm_ep_helper(yarpWholeBodyInterface TYPE GIT
@@ -16,4 +17,5 @@ ycm_ep_helper(yarpWholeBodyInterface TYPE GIT
               DEPENDS YARP
                       ICUB
                       iDynTree
-                      wholeBodyInterface)
+                      wholeBodyInterface
+                      icub-models)


### PR DESCRIPTION
Add icub-models repository to the superbuild as a dependency of yarpWholeBodyInterface, for substituting (one day) the urdf models used by estimation and control devices.