### PR TITLE
[WIP] Added icub-models to the superbuild

### DIFF
--- a/cmake/Buildicub-models.cmake
+++ b/cmake/Buildicub-models.cmake
@@ -1,0 +1,8 @@
+include(YCMEPHelper)
+
+ycm_ep_helper(icub-models
+              TYPE GIT
+              STYLE GITHUB
+              REPOSITORY robotology-playground/icub-models.git
+              TAG master
+              COMPONENT main)

--- a/cmake/BuildyarpWholeBodyInterface.cmake
+++ b/cmake/BuildyarpWholeBodyInterface.cmake
@@ -5,6 +5,7 @@ find_or_build_package(YARP QUIET)
 find_or_build_package(ICUB QUIET)
 find_or_build_package(iDynTree QUIET)
 find_or_build_package(wholeBodyInterface QUIET)
+find_or_build_package(icub-models QUIET)
 
 
 ycm_ep_helper(yarpWholeBodyInterface TYPE GIT
@@ -16,4 +17,5 @@ ycm_ep_helper(yarpWholeBodyInterface TYPE GIT
               DEPENDS YARP
                       ICUB
                       iDynTree
-                      wholeBodyInterface)
+                      wholeBodyInterface
+                      icub-models)


### PR DESCRIPTION
I opened a new pull request for this modification. The idea is to add icub-models to the superbuild, and use the models given from this repo instead of the ones stored inside yarp-wholebodyinterface (that are outdated). Before merging, it is necessary to test the new model on the real robot. Also, pleas note that currently the models are not installed in the default search path "$CODYCO_ROOT/build/install/share/codyco" but instead are inside "$CODYCO_ROOT/build/install/share/iCub". Check the path inside your `.bashrc` to see which models are taken.