### PR TITLE
Set KDL to off by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,8 @@ option(CODYCO_USES_OCTAVE "Enable compilation of software that depend on Octave"
 
 # Options related to optional dependencies 
 option(CODYCO_USES_OROCOS_BFL_BERDY "Forked Orocos Bayesian Filtering Library" FALSE)
-option(CODYCO_USES_KDL "Enable compilation of software that depends on KDL" TRUE)
+option(CODYCO_USES_KDL "Enable compilation of software that depends on KDL" FALSE)
+mark_as_advanced(CODYCO_USES_KDL)
 option(CODYCO_BUILD_ICUB_MODEL_GENERATOR "Enable compilation of the icub-model-generator" FALSE)
 option(CODYCO_BUILD_OCRA_MODULES "Enable compilation of ISIR controllers" FALSE)
 option(CODYCO_BUILD_QPOASES "Enable compilation of qpOASES" TRUE)

--- a/cmake/BuildiDynTree.cmake
+++ b/cmake/BuildiDynTree.cmake
@@ -28,11 +28,17 @@ if(${CODYCO_USES_KDL})
     find_or_build_package(orocos_kdl QUIET NO_CMAKE_PACKAGE_REGISTRY)
     list(APPEND iDynTree_DEPENDS orocos_kdl)
 
-    if( NOT MSVC )
+    if( NOT MSVC AND NOT APPLE )
         find_or_build_package(urdfdom_headers QUIET)
         find_or_build_package(urdfdom QUIET)
         list(APPEND iDynTree_DEPENDS urdfdom_headers)
         list(APPEND iDynTree_DEPENDS urdfdom)
+    endif()
+
+    # On macOS we allow only system URDFDOM
+    if( APPLE )
+      find_package(urdfdom_headers)
+      find_package(urdfdom)
     endif()
 endif()
 


### PR DESCRIPTION
Given that iDynTree does not need anymore KDL (if not for backward compatibility), we now disable KDL by default on the superbuild.

Furthermore, on macOS, if KDL is on, then the system urdfdom (e.g. installed by homebrew) is used.